### PR TITLE
Allow saving username and pull org membership from api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ keys/
 
 # Store your GitHub access token here for easy repeat use
 access-token.key
+username.txt

--- a/get-gpg-keys.sh
+++ b/get-gpg-keys.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 github_token_path=access-token.key
+github_username_path=username.txt
 
 # https://gist.github.com/davejamesmiller/1965569
 ask() {
@@ -38,8 +39,16 @@ ask() {
   done
 }
 
-echo "Enter your GitHub username"
-read -r github_username
+if [[ -f "$github_username_path" ]]; then
+  github_username="$(cat "$github_username_path")"
+else
+  echo "Enter your GitHub username"
+  read -r github_username
+
+  if ask "Do you want this username saved for future use?" Y; then
+    echo "$github_username" > "$github_username_path"
+  fi
+fi
 
 if [[ -f "$github_token_path" ]]; then
   github_token="$(cat "$github_token_path")"


### PR DESCRIPTION
This PR introduces two changes:
1. Adds ability to save github username
2. Automatically pulls and iterates over org membership instead of prompting